### PR TITLE
Data Background features

### DIFF
--- a/src/pymodaq/daq_scan.py
+++ b/src/pymodaq/daq_scan.py
@@ -962,6 +962,7 @@ class DAQ_Scan(QObject):
         self.dashboard.overshoot = False
         self.plot_2D_ini = False
         self.plot_1D_ini = False
+        self.bkg_container = None
         self.scan_positions = []
         self.curvilinear_values = []
         res = self.set_scan()
@@ -1111,7 +1112,7 @@ class DAQ_Scan(QObject):
         elif status[0] == "Timeout":
             self.ui.status_message.setText('Timeout occurred')
 
-    def update_1D_graph(self, datas, display_as_sequence=False, isadaptive=False):
+    def update_1D_graph(self, datas, display_as_sequence=False, isadaptive=False, bkg=None):
         """
             Update the 1D graphic window in the Graphic Interface with the given datas.
 
@@ -1179,7 +1180,12 @@ class DAQ_Scan(QObject):
 
             if isadaptive:
                 if self.ind_scan != 0:
-                    self.scan_data_1D = np.vstack((self.scan_data_1D, np.array([datas[key]['data'] for key in datas])))
+                    if bkg is not None:
+                        self.scan_data_1D = np.vstack(
+                            (self.scan_data_1D, np.array([datas[key]['data'] - bkg[key]['data'] for key in datas])))
+                    else:
+                        self.scan_data_1D = np.vstack(
+                            (self.scan_data_1D, np.array([datas[key]['data'] for key in datas])))
                 if not display_as_sequence:
                     self.scan_x_axis = np.array(self.scan_positions)
                 else:
@@ -1191,7 +1197,13 @@ class DAQ_Scan(QObject):
             else:
                 if self.scanner.scan_parameters.scan_subtype == 'Linear back to start':
                     if not utils.odd_even(self.ind_scan):
-                        self.scan_data_1D[int(self.ind_scan / 2), :] = np.array([datas[key]['data'] for key in datas])
+                        if bkg is not None:
+                            self.scan_data_1D[int(self.ind_scan / 2), :] = \
+                                np.array([datas[key]['data'] - bkg[key]['data'] for key in datas])
+                        else:
+                            self.scan_data_1D[int(self.ind_scan / 2), :] = \
+                                np.array([datas[key]['data'] for key in datas])
+
                         if self.settings.child('scan_options', 'scan_average').value() > 1:
                             self.scan_data_1D_average[self.ind_scan, :] = \
                                 (self.ind_average * self.scan_data_1D_average[
@@ -1199,7 +1211,12 @@ class DAQ_Scan(QObject):
                                     int(self.ind_scan / 2), :]) / (self.ind_average + 1)
 
                 else:
-                    self.scan_data_1D[self.ind_scan, :] = np.array([datas[key]['data'] for key in datas])
+                    if bkg is not None:
+                        self.scan_data_1D[self.ind_scan, :] = \
+                            np.array([datas[key]['data']-bkg[key]['data'] for key in datas])
+                    else:
+                        self.scan_data_1D[self.ind_scan, :] = \
+                            np.array([datas[key]['data'] for key in datas])
                     if self.settings.child('scan_options', 'scan_average').value() > 1:
                         self.scan_data_1D_average[self.ind_scan, :] = \
                             (self.ind_average * self.scan_data_1D_average[self.ind_scan, :] + self.scan_data_1D[
@@ -1232,7 +1249,7 @@ class DAQ_Scan(QObject):
         except Exception as e:
             logger.exception(str(e))
 
-    def update_2D_graph(self, datas, display_as_sequence=False, isadaptive=False):
+    def update_2D_graph(self, datas, display_as_sequence=False, isadaptive=False, bkg=None):
         """
             Update the 2D graphic window in the Graphic Interface with the given datas (if not none).
 
@@ -1269,8 +1286,12 @@ class DAQ_Scan(QObject):
                         self.scan_x_axis2D = np.array(self.scan_positions)[:, 0]
                         self.scan_y_axis = np.array(self.scan_positions)[:, 1]
                         key = list(datas.keys())[0]
-                        self.scan_data_2D = np.hstack((self.scan_positions[-1], datas[key]['data']))
-
+                        if bkg is not None:
+                            self.scan_data_2D = \
+                                np.hstack((self.scan_positions[-1], datas[key]['data'] - bkg[key]['data']))
+                        else:
+                            self.scan_data_2D = \
+                                np.hstack((self.scan_positions[-1], datas[key]['data']))
                     else:
                         self.scan_x_axis2D = self.scanner.scan_parameters.axes_unique[0]
                         self.scan_y_axis = self.scanner.scan_parameters.axes_unique[1]
@@ -1304,7 +1325,11 @@ class DAQ_Scan(QObject):
                     ind_pos_axis_2 = self.scanner.scan_parameters.axes_indexes[self.ind_scan, 1]
                     for ind_plot in range(min((3, len(datas)))):
                         keys = list(datas.keys())
-                        self.scan_data_2D[ind_plot][ind_pos_axis_2, ind_pos_axis_1] = datas[keys[ind_plot]]['data']
+                        if bkg is not None:
+                            self.scan_data_2D[ind_plot][ind_pos_axis_2, ind_pos_axis_1] = \
+                                datas[keys[ind_plot]]['data'] - bkg[keys[ind_plot]]['data']
+                        else:
+                            self.scan_data_2D[ind_plot][ind_pos_axis_2, ind_pos_axis_1] = datas[keys[ind_plot]]['data']
 
                         if self.settings.child('scan_options', 'scan_average').value() > 1:
                             self.scan_data_2D_average[ind_plot][ind_pos_axis_2, ind_pos_axis_1] = \
@@ -1319,8 +1344,13 @@ class DAQ_Scan(QObject):
                 else:
                     if self.ind_scan != 0:
                         key = list(datas.keys())[0]
-                        self.scan_data_2D = np.vstack((self.scan_data_2D,
-                                                       np.hstack((self.scan_positions[-1], datas[key]['data']))))
+                        if bkg is not None:
+                            self.scan_data_2D = np.vstack((self.scan_data_2D,
+                                                       np.hstack((self.scan_positions[-1], datas[key]['data'] -
+                                                                  bkg[key]['data']))))
+                        else:
+                            self.scan_data_2D = np.vstack((self.scan_data_2D,
+                                                           np.hstack((self.scan_positions[-1], datas[key]['data']))))
                     if len(self.scan_data_2D) > 3:  # at least 3 point to make a triangulation image
                         self.ui.scan2D_graph.setImage(data_spread=self.scan_data_2D)
 
@@ -1392,7 +1422,11 @@ class DAQ_Scan(QObject):
                 if self.scanner.scan_parameters.scan_subtype == 'Linear back to start':
                     if not utils.odd_even(self.ind_scan):
                         for ind_plot, key in enumerate(datas.keys()):
-                            self.scan_data_2D[ind_plot][:, int(self.ind_scan / 2)] = datas[key]['data']
+                            if bkg is not None:
+                                self.scan_data_2D[ind_plot][:, int(self.ind_scan / 2)] = datas[key]['data'] - \
+                                                                                         bkg[key]['data']
+                            else:
+                                self.scan_data_2D[ind_plot][:, int(self.ind_scan / 2)] = datas[key]['data']
                             if self.settings.child('scan_options', 'scan_average').value() > 1:
                                 self.scan_data_2D_average[ind_plot][:, int(self.ind_scan / 2)] = \
                                     (self.ind_average * self.scan_data_2D_average[ind_plot][
@@ -1407,7 +1441,11 @@ class DAQ_Scan(QObject):
                     for ind_plot, key in enumerate(datas.keys()):
                         if ind_plot >= 3:
                             break
-                        self.scan_data_2D[ind_plot][:, ind_pos_axis] = datas[key]['data']
+                        if bkg is not None:
+                            self.scan_data_2D[ind_plot][:, ind_pos_axis] = datas[key]['data'] - bkg[key]['data']
+                        else:
+                            self.scan_data_2D[ind_plot][:, ind_pos_axis] = datas[key]['data']
+
                         if self.settings.child('scan_options', 'scan_average').value() > 1:
                             self.scan_data_2D_average[ind_plot][:, self.ind_scan] = \
                                 (self.ind_average * self.scan_data_2D_average[ind_plot][:, ind_pos_axis] + datas[key][
@@ -1483,6 +1521,13 @@ class DAQ_Scan(QObject):
         if 'curvilinear' in datas:
             self.curvilinear_values.append(datas['curvilinear'])
 
+        if self.bkg_container is None:
+            det_name = self.settings.child('scan_options', 'plot_from').value()
+            det_mod = self.modules_manager.get_mod_from_name(det_name)
+            if det_mod.bkg is not None and det_mod.is_bkg:
+                self.bkg_container = OrderedDict([])
+                det_mod.process_data(det_mod.bkg, self.bkg_container)
+
         try:
             if scan_type == 'Scan1D' or \
                     (scan_type == 'Sequential' and self.scanner.scan_parameters.Naxes == 1) or \
@@ -1491,14 +1536,22 @@ class DAQ_Scan(QObject):
 
                 if 'data0D' in datas['datas'].keys():
                     if not (datas['datas']['data0D'] is None or datas['datas']['data0D'] == OrderedDict()):
+                        if self.bkg_container is None:
+                            bkg = None
+                        else:
+                            bkg = self.bkg_container['data0D']
                         self.update_1D_graph(datas['datas']['data0D'], display_as_sequence=display_as_sequence,
-                                             isadaptive=isadaptive)
+                                             isadaptive=isadaptive, bkg=bkg)
                     else:
                         self.scan_data_1D = []
                 if 'data1D' in datas['datas'].keys():
                     if not (datas['datas']['data1D'] is None or datas['datas']['data1D'] == OrderedDict()):
+                        if self.bkg_container is None:
+                            bkg = None
+                        else:
+                            bkg = self.bkg_container['data1D']
                         self.update_2D_graph(datas['datas']['data1D'], display_as_sequence=display_as_sequence,
-                                             isadaptive=isadaptive)
+                                             isadaptive=isadaptive, bkg=bkg)
                     # else:
                     #     self.scan_data_2D = []
 
@@ -1509,8 +1562,12 @@ class DAQ_Scan(QObject):
 
                 if 'data0D' in datas['datas'].keys():
                     if not (datas['datas']['data0D'] is None or datas['datas']['data0D'] == OrderedDict()):
+                        if self.bkg_container is None:
+                            bkg = None
+                        else:
+                            bkg = self.bkg_container['data0D']
                         self.update_2D_graph(datas['datas']['data0D'], display_as_sequence=display_as_sequence,
-                                             isadaptive=isadaptive or tabular2D)
+                                             isadaptive=isadaptive or tabular2D, bkg=bkg)
                     else:
                         self.scan_data_2D = []
 
@@ -1660,6 +1717,11 @@ class DAQ_Scan_Acquisition(QObject):
             if self.h5saver.settings.child(('save_2D')).value():
                 data_types.extend(['data2D', 'dataND'])
 
+            det_mod = self.modules_manager.get_mod_from_name(det_name)
+            if det_mod.bkg is not None and det_mod.is_bkg:
+                bkg_container = OrderedDict([])
+                det_mod.process_data(det_mod.bkg, bkg_container)
+
             for data_type in data_types:
                 if data_type in datas.keys():
                     if datas[data_type] is not None:
@@ -1669,7 +1731,6 @@ class DAQ_Scan_Acquisition(QObject):
                                     ('save_raw_only')).value() and 'raw' not in data_raw_roi):
                                 if not self.h5saver.is_node_in_group(det_group, data_type):
                                     self.channel_arrays[det_name][data_type] = OrderedDict([])
-
                                     data_group = self.h5saver.add_data_group(det_group, data_type)
                                     for ind_channel, channel in enumerate(datas[data_type]):  # list of OrderedDict
                                         if not (
@@ -1679,6 +1740,13 @@ class DAQ_Scan_Acquisition(QObject):
                                             channel_group = self.h5saver.add_CH_group(data_group, title=channel)
                                             self.channel_arrays[det_name][data_type]['parent'] = channel_group
                                             data_tmp = datas[data_type][channel]
+
+                                            if det_mod.bkg is not None and det_mod.is_bkg:
+                                                if channel in bkg_container[data_type]:
+                                                    data_tmp['bkg'] = bkg_container[data_type][channel]['data']
+                                                    if data_tmp['bkg'].shape == ():  # in case one get a numpy.float64 object
+                                                        data_tmp['bkg'] = np.array([data_tmp['bkg']])
+
                                             self.channel_arrays[det_name][data_type][channel] = \
                                                 self.h5saver.add_data(channel_group,
                                                                       data_tmp,

--- a/src/pymodaq/daq_viewer/daq_viewer_main.py
+++ b/src/pymodaq/daq_viewer/daq_viewer_main.py
@@ -404,6 +404,10 @@ class DAQ_Viewer(QtWidgets.QWidget, QObject):
                 if self.h5saver_continuous.settings.child(('save_2D')).value():
                     data_dims.extend(['data2D', 'dataND'])
 
+                if self.bkg is not None and self.is_bkg:
+                    bkg_container = OrderedDict([])
+                    self.process_data(self.bkg, bkg_container)
+
                 for data_dim in data_dims:
                     if data_dim in datas.keys() and len(datas[data_dim]) != 0:
                         if not self.h5saver_continuous.is_node_in_group(self.continuous_group, data_dim):
@@ -414,12 +418,12 @@ class DAQ_Viewer(QtWidgets.QWidget, QObject):
 
                                 channel_group = self.h5saver_continuous.add_CH_group(data_group, title=channel)
                                 self.channel_arrays[data_dim]['parent'] = channel_group
-                                self.channel_arrays[data_dim][channel] = self.h5saver_continuous.add_data(channel_group,
-                                                                                                          datas[
-                                                                                                              data_dim][
-                                                                                                              channel],
-                                                                                                          scan_type='scan1D',
-                                                                                                          enlargeable=True)
+                                if self.bkg is not None and self.is_bkg:
+                                    if channel in bkg_container[data_dim]:
+                                        datas[data_dim][channel]['bkg'] = bkg_container[data_dim][channel]['data']
+                                self.channel_arrays[data_dim][channel] = \
+                                    self.h5saver_continuous.add_data(channel_group, datas[data_dim][channel],
+                                                                     scan_type='scan1D', enlargeable=True)
                 self.is_continuous_initialized = True
 
             dt = np.array([time.perf_counter() - self.ini_time])


### PR DESCRIPTION
New scheme for background substraction and saving

The DAQ_Viewer allows a background to be recorded internally. It will not be anymore automatically saved in a separated file but kept in memory. Then if a user save its data (either a snap or continuous saving in DAQ_Viewer) or within the DAQ_Scan extension, the background will be saved in the HDF5 file as a node. The H5Browser, will look for such a node and display subtracted data if the node is present. 
Therefore raw data and background data are all present within the same file