### PR TITLE
Fix pyqtgraph version: deprecation of method setResizeMode of Qt.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires=
     #pyqt5
     numpy
     scipy
-    pyqtgraph==0.12.4
+    pyqtgraph>=0.12
     easydict
     tables==3.6.1; python_version<"3.9"
     tables>=3.7.0; python_version>"3.8"

--- a/src/pymodaq/daq_utils/parameter/pymodaq_ptypes/table.py
+++ b/src/pymodaq/daq_utils/parameter/pymodaq_ptypes/table.py
@@ -107,7 +107,7 @@ class TableParameterItem(WidgetParameterItem):
         if 'height' not in opts:
             opts['height'] = 200
         w.setMaximumHeight(opts['height'])
-        w.horizontalHeader().setResizeMode(QtWidgets.QHeaderView.Stretch)
+        w.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
         # self.table.setReadOnly(self.param.opts.get('readonly', False))
         w.value = w.get_table_value
         w.setValue = w.set_table_value

--- a/src/pymodaq/daq_utils/parameter/pymodaq_ptypes/tableview.py
+++ b/src/pymodaq/daq_utils/parameter/pymodaq_ptypes/tableview.py
@@ -94,7 +94,7 @@ class TableViewParameterItem(WidgetParameterItem):
 
         if 'tip' in opts:
             w.setToolTip(opts['tip'])
-        w.horizontalHeader().setResizeMode(QtWidgets.QHeaderView.Stretch)
+        w.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
         #w.setMaximumHeight(200)
         # self.table.setReadOnly(self.param.opts.get('readonly', False))
         w.value = w.get_table_value


### PR DESCRIPTION
See [https://stackoverflow.com/questions/42743141/no-member-named-setresizemode-in-qheaderview-convert-qt-4-7-to-qt-5-8](https://stackoverflow.com/questions/42743141/no-member-named-setresizemode-in-qheaderview-convert-qt-4-7-to-qt-5-8).

I found two files where this method is used. I hope I did not miss others ;)